### PR TITLE
Directly map 'TOTP' field for one-time passwords

### DIFF
--- a/enpass-to-keepass.py
+++ b/enpass-to-keepass.py
@@ -12,8 +12,8 @@ import argparse
 import csv
 import json
 
-DIRECTLY_MAPPED_FIELDS = ["url", "username", "password"]
-CSV_HEADERS = ["title", "url", "username", "password", "group", "updated_at", "notes"]
+DIRECTLY_MAPPED_FIELDS = ["url", "username", "password", "totp"]
+CSV_HEADERS = ["title", "url", "username", "password", "group", "updated_at", "notes", "totp"]
 FIELD_ALIASES = {
     "website": "url",
     "e-mail": "email",

--- a/enpass-to-keepass.py
+++ b/enpass-to-keepass.py
@@ -20,6 +20,7 @@ FIELD_ALIASES = {
     "login": "username",
     "benutzername": "username",
     "kennwort": "password",
+    "one-time code": "totp",
 }
 
 extra_keys = set([])


### PR DESCRIPTION
Since KeePassXC can import TOTP seeds, the TOTP field can be mapped into its own column.

`TOTP` was the default field name for `One-time Code`s in an earlier version of Enpass.